### PR TITLE
add false flag for shift on ctrl-tab keypress

### DIFF
--- a/src/predicates.js
+++ b/src/predicates.js
@@ -115,8 +115,10 @@ module.exports = {
   CTRL_P: function({ ctrlKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) && keyCode === kc('p'));
   },
-  CTRL_TAB: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('tab'));
+  CTRL_TAB: function({ ctrlKey, metaKey, shiftKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      shiftKey === false &&
+      keyCode === kc('tab'));
   },
   CTRL_SHIFT_TAB: function({ ctrlKey, metaKey, shiftKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) &&


### PR DESCRIPTION
#### What's this PR do?

Fixes a bug with ctrl-tab. Pressing ctrl-shift-tab would fire both a ctrl-shift-tab and ctrl-tab event, because shift was not being excluded in ctrl-tab. This adds the exclusion.
#### Where should the reviewer start?

Link to this branch in iggins from ChromeIDE. Create a few test files. Be sure some are saved and some are unsaved. The bug only presents itself during the transition from a saved to unsaved file.
#### How should this be manually tested?

Press Ctrl-Shift-Tab to navigate between files. You should move up one file at a time and loop to the bottom once you hit the top.
#### Any background context you want to provide?

No
#### What are the relevant tickets?

None
#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
