### PR TITLE
Predicate logic

### DIFF
--- a/src/predicates.js
+++ b/src/predicates.js
@@ -3,35 +3,65 @@
 const kc = require('keycode');
 
 module.exports = {
-  CTRL_A: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('a'));
+  CTRL_A: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('a'));
   },
-  CTRL_C: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('c'));
+  CTRL_C: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('c'));
   },
-  CTRL_F: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('f'));
+  CTRL_F: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('f'));
   },
-  CTRL_V: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('v'));
+  CTRL_V: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('v'));
   },
-  CTRL_X: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('x'));
+  CTRL_X: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('x'));
   },
-  CTRL_Z: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('z'));
+  CTRL_Z: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('z'));
   },
-  CTRL_G: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('g'));
+  CTRL_G: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('g'));
   },
-  CTRL_W: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('w'));
+  CTRL_W: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('w'));
   },
-  CTRL_SHIFT_Z: function({ ctrlKey, metaKey, keyCode, shiftKey }){
-    return ((ctrlKey === true || metaKey === true) && shiftKey === true && keyCode === kc('z'));
+  CTRL_SHIFT_Z: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      shiftKey === true &&
+      altKey === false &&
+      keyCode === kc('z'));
   },
-  CTRL_SHIFT_G: function({ ctrlKey, metaKey, keyCode, shiftKey }){
-    return ((ctrlKey === true || metaKey === true) && shiftKey === true && keyCode === kc('g'));
+  CTRL_SHIFT_G: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      shiftKey === true &&
+      altKey === false &&
+      keyCode === kc('g'));
   },
   TAB: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
@@ -40,20 +70,38 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('tab'));
   },
-  SHIFT_TAB: function({ shiftKey, keyCode }){
-    return (shiftKey === true && keyCode === kc('tab'));
+  SHIFT_TAB: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (shiftKey === true &&
+      altKey === false &&
+      ctrlKey === false &&
+      metaKey === false &&
+      keyCode === kc('tab');
   },
-  ALT_SHIFT_TAB: function({ altKey, shiftKey, keyCode }){
-    return (altKey === true && shiftKey === true && keyCode === kc('tab'));
+  ALT_SHIFT_TAB: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (altKey === true &&
+      shiftKey === true &&
+      ctrlKey === false &&
+      metaKey === false &&
+      keyCode === kc('tab'));
   },
-  ALT_TAB: function({ altKey, keyCode }){
-    return (altKey === true && keyCode === kc('tab'));
+  ALT_TAB: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (altKey === true &&
+      shiftKey === false &&
+      ctrlKey === false &&
+      metaKey === false &&
+      keyCode === kc('tab'));
   },
-  ALT_CTRL_F: function({ altKey, ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && altKey === true && keyCode === kc('f'));
+  ALT_CTRL_F: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === true &&
+      shiftKey === false &&
+      keyCode === kc('f'));
   },
-  ALT_CTRL_G: function({ altKey, ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && altKey === true && keyCode === kc('g'));
+  ALT_CTRL_G: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === true &&
+      shiftKey === false &&
+      keyCode === kc('g'));
   },
   F3: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
@@ -62,8 +110,12 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('f3'));
   },
-  SHIFT_F3: function({ shiftKey, keyCode }){
-    return (shiftKey === true && keyCode === kc('f3'));
+  SHIFT_F3: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (shiftKey === true &&
+      ctrlKey === false &&
+      metaKey === false &&
+      altKey === false &&
+      keyCode === kc('f3'));
   },
   F4: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
@@ -72,35 +124,74 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('f4'));
   },
-  CTRL_F4: function({ ctrlKey, keyCode }){
-    return (ctrlKey === true && keyCode === kc('f4'));
+  CTRL_F4: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('f4'));
   },
-  CTRL_HOME: function({ ctrlKey, keyCode }){
-    return (ctrlKey === true && keyCode === kc('home'));
+  CTRL_HOME: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('home'));
   },
-  CTRL_META_LEFT: function({ ctrlKey, metaKey, keyCode }){
-    return (ctrlKey === true && metaKey === true && keyCode === kc('left'));
+  CTRL_META_LEFT: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      metaKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      keyCode === kc('left'));
   },
-   CTRL_META_RIGHT: function({ ctrlKey, metaKey, keyCode }){
-    return (ctrlKey === true && metaKey === true && keyCode === kc('right'));
+   CTRL_META_RIGHT: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      metaKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      keyCode === kc('right'));
   },
-  CTRL_END: function({ ctrlKey, keyCode }){
-    return (ctrlKey === true && keyCode === kc('end'));
+  CTRL_END: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('end'));
   },
-  CTRL_UP: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('up'));
+  CTRL_UP: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('up'));
   },
-  CTRL_DOWN: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('down'));
+  CTRL_DOWN: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('down'));
   },
-  CTRL_MINUS: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('-'));
+  CTRL_MINUS: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('-'));
   },
-  CTRL_EQUALS: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('='));
+  CTRL_EQUALS: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return (ctrlKey === true &&
+      shiftKey === false &&
+      altKey === false &&
+      metaKey === false &&
+      keyCode === kc('='));
   },
-  CTRL_O: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('o'));
+  CTRL_O: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('o'));
   },
   BACSPACE: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
@@ -109,32 +200,41 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('backspace'));
   },
-  CTRL_S: function({ ctrlKey, metaKey, shiftKey, keyCode }){
+  CTRL_S: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
       shiftKey === false &&
       keyCode === kc('s'));
   },
   CTRL_SHIFT_S: function({ altKey, ctrlKey, metaKey, shiftKey, keyCode}){
     return ((ctrlKey === true || metaKey === true) &&
       shiftKey === true &&
-      keyCode === kc('s') &&
-      altKey === false);
+      altKey === false) &&
+      keyCode === kc('s');
   },
-  CTRL_P: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('p'));
-  },
-  CTRL_TAB: function({ ctrlKey, metaKey, shiftKey, keyCode }){
+  CTRL_P: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('p'));
+  },
+  CTRL_TAB: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
       shiftKey === false &&
       keyCode === kc('tab'));
   },
-  CTRL_SHIFT_TAB: function({ ctrlKey, metaKey, shiftKey, keyCode }){
+  CTRL_SHIFT_TAB: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) &&
       shiftKey === true &&
+      altKey === false &&
       keyCode === kc('tab'));
   },
-  CTRL_I: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('i'));
+  CTRL_I: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('i'));
   },
   F6: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
@@ -143,8 +243,11 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('f6'));
   },
-  CTRL_T: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('t'));
+  CTRL_T: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('t'));
   },
   F7: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
@@ -153,8 +256,11 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('f7'));
   },
-  CTRL_M: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('m'));
+  CTRL_M: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('m'));
   },
   CTRL_N: function({altKey, ctrlKey, metaKey, shiftKey, keyCode}){
     return ((ctrlKey === true || metaKey === true) &&
@@ -169,8 +275,11 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('f8'));
   },
-  CTRL_R: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('r'));
+  CTRL_R: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('r'));
   },
   F9: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -156,6 +156,12 @@ module.exports = {
   CTRL_M: function({ ctrlKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) && keyCode === kc('m'));
   },
+  CTRL_N: function({altKey, ctrlKey, metaKey, shiftKey, keyCode}){
+    return ((ctrlKey === true || metaKey === true) &&
+      altKey === false &&
+      shiftKey === false &&
+      keyCode === kc('n'));
+  },
   F8: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
       shiftKey === false &&

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -154,37 +154,33 @@ module.exports = {
   },
   CTRL_END: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === true &&
+      metaKey === false &&
       shiftKey === false &&
       altKey === false &&
-      metaKey === false &&
       keyCode === kc('end'));
   },
   CTRL_UP: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
-    return (ctrlKey === true &&
+    return ((ctrlKey === true || metaKey === true) &&
       shiftKey === false &&
       altKey === false &&
-      metaKey === false &&
       keyCode === kc('up'));
   },
   CTRL_DOWN: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
-    return (ctrlKey === true &&
+    return ((ctrlKey === true || metaKey === true) &&
       shiftKey === false &&
       altKey === false &&
-      metaKey === false &&
       keyCode === kc('down'));
   },
   CTRL_MINUS: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
-    return (ctrlKey === true &&
+    return ((ctrlKey === true || metaKey === true) &&
       shiftKey === false &&
       altKey === false &&
-      metaKey === false &&
       keyCode === kc('-'));
   },
   CTRL_EQUALS: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
-    return (ctrlKey === true &&
+    return ((ctrlKey === true || metaKey === true) &&
       shiftKey === false &&
       altKey === false &&
-      metaKey === false &&
       keyCode === kc('='));
   },
   CTRL_O: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
@@ -193,7 +189,7 @@ module.exports = {
       shiftKey === false &&
       keyCode === kc('o'));
   },
-  BACSPACE: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
+  BACKSPACE: function({ ctrlKey, shiftKey, altKey, metaKey, keyCode }){
     return (ctrlKey === false &&
       shiftKey === false &&
       altKey === false &&

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -114,6 +114,12 @@ module.exports = {
       shiftKey === false &&
       keyCode === kc('s'));
   },
+  CTRL_SHIFT_S: function({ altKey, ctrlKey, metaKey, shiftKey, keyCode}){
+    return ((ctrlKey === true || metaKey === true) &&
+      shiftKey === true &&
+      keyCode === kc('s') &&
+      altKey === false);
+  },
   CTRL_P: function({ ctrlKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) && keyCode === kc('p'));
   },

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -109,8 +109,10 @@ module.exports = {
       metaKey === false &&
       keyCode === kc('backspace'));
   },
-  CTRL_S: function({ ctrlKey, metaKey, keyCode }){
-    return ((ctrlKey === true || metaKey === true) && keyCode === kc('s'));
+  CTRL_S: function({ ctrlKey, metaKey, shiftKey, keyCode }){
+    return ((ctrlKey === true || metaKey === true) &&
+      shiftKey === false &&
+      keyCode === kc('s'));
   },
   CTRL_P: function({ ctrlKey, metaKey, keyCode }){
     return ((ctrlKey === true || metaKey === true) && keyCode === kc('p'));


### PR DESCRIPTION
#### What's this PR do?

It adjusts the predicate functions that ship with iggins to explicitly include the state of all modifier keys.  This is done to prevent conflicts and false triggers.  It also adds Ctrl-N and Ctrl-Shift-S
#### Where should the reviewer start?

Pull the branch and use in an iggins application.  
#### How should this be manually tested?

Test cases where activity is bound to a two-key combination and a similar three-key combination.  For example, CTRL-S may bound to one function and CTRL-SHIFT-S may be bound to a different function.  The changes in this update will ensure that the CTRL-S is not triggered because the state of the 'shift' key is made explicit as 'true' for the ctrl-shift-s case and 'false' for the ctrl-s case.
#### What are the relevant tickets?
#7 #8 #9
